### PR TITLE
Export Filled anchor

### DIFF
--- a/lib/flutter_portal.dart
+++ b/lib/flutter_portal.dart
@@ -1,4 +1,4 @@
-export 'package:flutter_portal/src/anchor.dart' show Anchor, Aligned, AxisFlag;
+export 'package:flutter_portal/src/anchor.dart' show Anchor, Aligned, AxisFlag, Filled;
 export 'package:flutter_portal/src/portal.dart' show Portal, PortalLabel;
 export 'package:flutter_portal/src/portal_target.dart'
     show PortalTarget, PortalNotFoundError;


### PR DESCRIPTION
This adds the missing export for the `Filled` anchor, so it's exported by default just as all other anchors.

Thus, the extra-import can be skipped in apps using this plugin and we avoid [this](https://dart-lang.github.io/linter/lints/implementation_imports.html) warning:

```dart
import 'package:flutter_portal/flutter_portal.dart';
import 'package:flutter_portal/src/anchor.dart';  // <-- can be skipped
```