### PR TITLE
== override parameters are non-nullable

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2159,7 +2159,7 @@ class EntryBuildSpyCall {
   final int value2;
 
   @override
-  bool operator ==(dynamic o) =>
+  bool operator ==(Object o) =>
       o is EntryBuildSpyCall && o.value1 == value1 && o.value2 == value2;
 
   @override


### PR DESCRIPTION
Make operator == override parameters non-nullable. See https://github.com/dart-lang/linter/issues/3441

Work towards https://github.com/dart-lang/sdk/issues/51038.