### PR TITLE
Updated widget_test and enhanced_composited_transform_test: wired down Material2 dependency

### DIFF
--- a/test/enhanced_composited_transform_test.dart
+++ b/test/enhanced_composited_transform_test.dart
@@ -16,6 +16,7 @@ void main() {
     PointerDownEvent? lastPointerDownEvent;
 
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Scaffold(
         body: Container(
           key: containerKey,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2139,6 +2139,7 @@ class Boilerplate extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         body: child,


### PR DESCRIPTION
Prepare for the change to the default value of `ThemeData.useMaterial3` coming in https://github.com/flutter/flutter/issues/127064. Currently the widget_test and enhanced_composited_transform_test tests depend on the UI being configured for Material2. While we're undergoing this transition, changed the MaterialApp created by the tests to specify `useMaterial3: false`. 