### PR TITLE
Update widget_test.dart for an upstream LayoutBuilder fix

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -42,6 +42,8 @@ Future<ByteData> fetchFont() async {
 Future<void> main() async {
   final fontLoader = FontLoader('Roboto')..addFont(fetchFont());
   await fontLoader.load();
+  setUp(() { LayoutBuilder.applyDoubleRebuildFix = true; });
+  tearDown(() { LayoutBuilder.applyDoubleRebuildFix = false; });
 
   testWidgets('can optionally delay close with a Duration', (tester) async {
     await tester.pumpWidget(
@@ -1365,7 +1367,7 @@ Future<void> main() async {
     expect(find.text('1'), findsOneWidget);
     expect(find.text('1 1'), findsOneWidget);
     expect(entryBuild.calls,
-        const [EntryBuildSpyCall(0, 1), EntryBuildSpyCall(1, 1)]);
+        const [EntryBuildSpyCall(1, 1)]);
   });
 
   testWidgets('layout builder between portal and entry on first build',

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1365,7 +1365,7 @@ Future<void> main() async {
     expect(find.text('1'), findsOneWidget);
     expect(find.text('1 1'), findsOneWidget);
     // https://github.com/fzyzcjy/flutter_portal/pull/113.
-    // expect(entryBuild.calls, const [EntryBuildSpyCall(0, 1), EntryBuildSpyCall(1, 1)]);    
+    // expect(entryBuild.calls, const [EntryBuildSpyCall(0, 1), EntryBuildSpyCall(1, 1)]);
   });
 
   testWidgets('layout builder between portal and entry on first build',

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1364,6 +1364,9 @@ Future<void> main() async {
 
     expect(find.text('1'), findsOneWidget);
     expect(find.text('1 1'), findsOneWidget);
+    // https://github.com/fzyzcjy/flutter_portal/pull/113.
+    //expect(entryBuild.calls,
+        //const [EntryBuildSpyCall(0, 1), EntryBuildSpyCall(1, 1)]);    
   });
 
   testWidgets('layout builder between portal and entry on first build',

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1365,8 +1365,7 @@ Future<void> main() async {
     expect(find.text('1'), findsOneWidget);
     expect(find.text('1 1'), findsOneWidget);
     // https://github.com/fzyzcjy/flutter_portal/pull/113.
-    //expect(entryBuild.calls,
-        //const [EntryBuildSpyCall(0, 1), EntryBuildSpyCall(1, 1)]);    
+    // expect(entryBuild.calls, const [EntryBuildSpyCall(0, 1), EntryBuildSpyCall(1, 1)]);    
   });
 
   testWidgets('layout builder between portal and entry on first build',

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -42,8 +42,6 @@ Future<ByteData> fetchFont() async {
 Future<void> main() async {
   final fontLoader = FontLoader('Roboto')..addFont(fetchFont());
   await fontLoader.load();
-  setUp(() { LayoutBuilder.applyDoubleRebuildFix = true; });
-  tearDown(() { LayoutBuilder.applyDoubleRebuildFix = false; });
 
   testWidgets('can optionally delay close with a Duration', (tester) async {
     await tester.pumpWidget(
@@ -1366,8 +1364,6 @@ Future<void> main() async {
 
     expect(find.text('1'), findsOneWidget);
     expect(find.text('1 1'), findsOneWidget);
-    expect(entryBuild.calls,
-        const [EntryBuildSpyCall(1, 1)]);
   });
 
   testWidgets('layout builder between portal and entry on first build',


### PR DESCRIPTION
LayoutBuilder migration: LayoutBuilders no longer do double layout (currently the fix is behind a temporary flag `LayoutBuilder.applyDoubleRebuildFix`).

Related flutter/flutter PR:  https://github.com/flutter/flutter/pull/147856

Unfortunately the presubmit checks are currently run against the stable branch of flutter which does not have the migration flag yet so I removed the `expect` statement altogether.

https://github.com/fzyzcjy/flutter_portal/blob/786cd79fb16f353c870e89958d29cf583e6c06b9/.github/workflows/build.yml#L14-L17