### PR TITLE
Remove non-functional `package_api_docs` lint

### DIFF
--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -88,7 +88,6 @@ linter:
     - one_member_abstracts
     - only_throw_errors
     - overridden_fields
-    - package_api_docs
     - package_names
     - package_prefixed_library_names
     - parameter_assignments


### PR DESCRIPTION
This lint hasn't been functional for a long time, so it's likely to removed (https://github.com/dart-lang/linter/issues/5107).