### PR TITLE
Disable two lint rules which are being removed.

### DIFF
--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -21,7 +21,6 @@ linter:
     - avoid_implementing_value_types
     - avoid_init_to_null
     - avoid_js_rounded_ints
-    - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     - avoid_print
     - avoid_private_typedef_functions
@@ -163,7 +162,6 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unrelated_type_equality_checks
-    - unsafe_html
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_is_even_rather_than_modulo


### PR DESCRIPTION
Each of these are going to be removed soon.

* avoid_null_checks_in_equality_operators
* unsafe_html

Work towards https://github.com/dart-lang/linter/issues/5063 and https://github.com/dart-lang/linter/issues/5001