### PR TITLE
docs(readme): replace pub.dartlang.org with pub.dev; normalize macOS; update Flutter docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build](https://github.com/fzyzcjy/flutter_portal/actions/workflows/build.yml/badge.svg)](https://github.com/fzyzcjy/flutter_portal/actions/workflows/build.yml)
-[![pub package](https://img.shields.io/pub/v/flutter_portal.svg)](https://pub.dartlang.org/packages/flutter_portal)
+[![pub package](https://img.shields.io/pub/v/flutter_portal.svg)](https://pub.dev/packages/flutter_portal)
 [![codecov](https://codecov.io/gh/fzyzcjy/flutter_portal/branch/master/graph/badge.svg)](https://codecov.io/gh/fzyzcjy/flutter_portal)
 
 # [flutter_portal](https://github.com/fzyzcjy/flutter_portal): Evolved `Overlay`/`OverlayEntry` - declarative not imperative, intuitive-context, and easy-alignment


### PR DESCRIPTION
Small documentation cleanup in README:
- Replace legacy `pub.dartlang.org` links with `pub.dev`
- Normalize platform spelling `MacOS` -> `macOS`
- Update `flutter.dev/docs/...` links to `docs.flutter.dev/...`

No code changes.